### PR TITLE
[UPDATE] improve Makefile and fix function prototypes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,28 @@
 CC=clang
-CFLAGS=-lcurses -Wall 
-SRCS=$(wildcard src/*.c)
-OBJS=$(patsubst src/%.c, obj/%.o, $(SRCS))
+CFLAGS=-Wall
+LDFLAGS=-lcurses -lm
 
-all: bin/connect4
+SRC_DIR=src
+OBJ_DIR=obj
+BIN_DIR=bin
 
-bin/connect4: $(OBJS)
-	$(CC) $(CFLAGS) -o $@ $^
+SRCS=$(wildcard $(SRC_DIR)/*.c)
+OBJS=$(patsubst $(SRC_DIR)/%.c, $(OBJ_DIR)/%.o, $(SRCS))
 
-obj/%.o: src/%.c
-	$(CC) $(CFLAGS) -c $^ -o $@
+TARGET=$(BIN_DIR)/connect4
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS) | $(BIN_DIR)
+	$(CC) $(LDFLAGS) -o $@ $^
+
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(BIN_DIR) $(OBJ_DIR):
+	mkdir -p $@
 
 clean:
-	rm -rf bin/* obj/*
+	rm -rf $(BIN_DIR)/* $(OBJ_DIR)/*
+
+.PHONY: all clean

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -1,9 +1,11 @@
 #ifndef _HELPERS_H_
 #define _HELPERS_H_
 
+#include <curses.h>
+
 // Prototypes
-void exit_curses();
-void getch_exit_curses();
-void wreset();
+void exit_curses(int code);
+void getch_exit_curses(int code);
+void wreset(WINDOW *win);
 
 #endif

--- a/src/views.c
+++ b/src/views.c
@@ -165,7 +165,7 @@ int main_menu_view()
       case 3:
         // Leave the game
         refresh();
-        exit_curses();
+        exit_curses(0);
         return 0;
       }
     }


### PR DESCRIPTION
- Updated Makefile:  
  - Split CFLAGS and LDFLAGS to separate compilation and linking.
  - Link the math library (-lm) to resolve undefined references (round, sqrt, log).
  - Remove -lcurses from object compilation; use only during linking.
  -  Ensure obj/ and bin/ directories are automatically created.
- Fixed function prototypes in helpers.h to match definitions:
  - exit_curses(int code)
  - getch_exit_curses(int code)
  - wreset(WINDOW *win)