### PR TITLE
[FIX] fix out of bound access in mcts.c

### DIFF
--- a/src/mcts.c
+++ b/src/mcts.c
@@ -27,7 +27,7 @@ int get_random_available_action(int b[][WIDTH])
   }
 
   if (available_actions_count == WIDTH)
-    return rand() % MAX_CHILD_NODES_NUM + 1;
+    return rand() % WIDTH;
 
   available_actions = malloc(sizeof(int) * available_actions_count);
 


### PR DESCRIPTION
This PR fixes a potential out-of-bounds access in mcts.c that could occur when rand() % MAX_CHILD_NODES_NUM + 1 produces a value equal to MAX_CHILD_NODES_NUM.